### PR TITLE
Use final for virtual methods on private impl of mbgl::View

### DIFF
--- a/src/qmapboxgl_p.h
+++ b/src/qmapboxgl_p.h
@@ -21,10 +21,10 @@ public:
     virtual ~QMapboxGLPrivate();
 
     // mbgl::View implementation.
-    void activate() override {}
-    void deactivate() override;
-    void notify() override {}
-    void invalidate(std::function<void()> renderCallback) override;
+    void activate() final {}
+    void deactivate() final;
+    void notify() final {}
+    void invalidate(std::function<void()> renderCallback) final;
 
     mbgl::DefaultFileSource fileSource;
     mbgl::Map map;


### PR DESCRIPTION
This is a private implementation, so we know that no one else will
inherit from that.
